### PR TITLE
Fix tfdeploy under Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ sudo: false
 warnings_are_errors: false
 
 env:
-  TF_VERSION="1.4"
+  - TF_VERSION="1.4"
+  - TF_VERSION="1.7"
 
 cache:
   packages: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ cache:
   directories:
     - $HOME/.cache/pip
 
+r_packages:
+  - covr
+
 before_script:
   - source scripts/travis_install.sh
 
@@ -25,3 +28,6 @@ after_failure:
     cd tests
     travis_wait 30 Rscript ../.travis.R
     sleep 2
+
+after_success:
+  - Rscript -e 'covr::codecov()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,11 @@ before_script:
 script:
   - |
     R CMD build .
-    R CMD check --no-build-vignettes --no-manual tfdeploy*tar.gz
+    R CMD check --no-build-vignettes --no-manual --no-tests tfdeploy*tar.gz
+    travis_wait 20 Rscript -e 'covr::codecov()'
 
 after_failure:
   - |
     cd tests
     travis_wait 30 Rscript ../.travis.R
     sleep 2
-
-after_success:
-  - Rscript -e 'covr::codecov()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ sudo: false
 warnings_are_errors: false
 
 env:
-  - TF_VERSION="1.4"
-  - TF_VERSION="1.7"
+  TF_VERSION="1.7"
 
 cache:
   packages: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: tfdeploy
 Type: Package
 Title: tfdeploy: Deploy TensorFlow Models
-Version: 0.5
+Version: 0.5.1
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person(family = "RStudio", role = c("cph"))

--- a/R/serve.R
+++ b/R/serve.R
@@ -175,7 +175,7 @@ message_serve_start <- function(host, port, graph) {
   message()
   message("Starting server under ", hostname, " with the following API entry points:")
 
-  for (signature_name in graph$signature_def$keys()) {
+  for (signature_name in py_dict_get_keys(graph$signature_def)) {
     message("  ", hostname, "/", signature_name, "/predict/")
   }
 }

--- a/R/swagger.R
+++ b/R/swagger.R
@@ -58,7 +58,7 @@ swagger_path <- function(signature_name, signature_id) {
 }
 
 swagger_paths <- function(signature_def) {
-  path_names <- signature_def$keys()
+  path_names <- py_dict_get_keys(signature_def)
   path_values <- lapply(seq_along(path_names), function(path_index) {
     swagger_path(path_names[[path_index]], path_index)
   })
@@ -173,7 +173,7 @@ swagger_input_tensor_def <- function(signature_entry, tensor_input_name) {
 }
 
 swagger_def <- function(signature_entry, signature_id) {
-  tensor_input_names <- signature_entry$inputs$keys()
+  tensor_input_names <- py_dict_get_keys(signature_entry$inputs)
 
   swagger_input_defs <- lapply(tensor_input_names, function(tensor_input_name) {
     swagger_input_tensor_def(
@@ -204,7 +204,7 @@ swagger_def <- function(signature_entry, signature_id) {
 }
 
 swagger_defs <- function(signature_def) {
-  defs_names <- signature_def$keys()
+  defs_names <- py_dict_get_keys(signature_def)
   defs_values <- lapply(seq_along(defs_names), function(defs_index) {
     swagger_def(signature_def$get(defs_names[[defs_index]]), defs_index)
   })

--- a/R/tensor.R
+++ b/R/tensor.R
@@ -9,7 +9,7 @@ tensor_is_multi_instance <- function(tensor) {
 
 # Retrieves the input and output tensors from a graph as a named list.
 tensor_get_boundaries <- function(graph, signature_def, signature_name) {
-  signature_names <- signature_def$keys()
+  signature_names <- py_dict_get_keys(signature_def)
   if (!signature_name %in% signature_names) {
     stop(
       "Signature '", signature_name, "' not available in model signatures. ",
@@ -18,8 +18,8 @@ tensor_get_boundaries <- function(graph, signature_def, signature_name) {
 
   signature_obj <- signature_def$get(signature_name)
 
-  signature_input_names <- signature_obj$inputs$keys()
-  signature_output_names <- signature_obj$outputs$keys()
+  signature_input_names <- py_dict_get_keys(signature_obj$inputs)
+  signature_output_names <- py_dict_get_keys(signature_obj$outputs)
 
   if (length(signature_input_names) == 0) {
     stop("Signature '", signature_name, "' contains no inputs.")

--- a/R/utils.R
+++ b/R/utils.R
@@ -13,7 +13,12 @@ append_predictions_class <- function(x) {
 
 py_dict_get_keys <- function(x) {
   py_builtins <- reticulate::import_builtins()
+  keys <- x$keys()
 
   # python 3 returns keys as KeysView not list
-  py_builtins$list(x$keys())
+  if (!is.list(keys) && !is.character(keys)) {
+    keys <- as.list(py_builtins$list(x$keys()))
+  }
+
+  keys
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -10,3 +10,10 @@ append_predictions_class <- function(x) {
   class(x) <- c(class(x), "savedmodel_predictions")
   x
 }
+
+py_builtins <- reticulate::import_builtins()
+
+py_dict_get_keys <- function(x) {
+  # python 3 returns keys as KeysView not list
+  py_builtins$list(x$keys())
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -11,9 +11,9 @@ append_predictions_class <- function(x) {
   x
 }
 
-py_builtins <- reticulate::import_builtins()
-
 py_dict_get_keys <- function(x) {
+  py_builtins <- reticulate::import_builtins()
+
   # python 3 returns keys as KeysView not list
   py_builtins$list(x$keys())
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 
 ## Deploying TensorFlow Models from R
 
+[![Build
+Status](https://travis-ci.org/rstudio/tfdeploy.svg?branch=master)](https://travis-ci.org/rstudio/tfdeploy)
+[![CRAN\_Status\_Badge](https://www.r-pkg.org/badges/version/tfdeploy)](https://cran.r-project.org/package=tfdeploy)
+[![codecov](https://codecov.io/gh/rstudio/tfdeploy/branch/master/graph/badge.svg)](https://codecov.io/gh/rstudio/tfdeploy)
+
 While TensorFlow models are typically defined and trained using R or Python code, it is possible to deploy TensorFlow models in a wide variety of environments without any runtime dependency on R or Python:
 
 - [TensorFlow Serving](https://www.tensorflow.org/serving/) is an open-source software library for serving TensorFlow models using a [gRPC](https://grpc.io/) interface.


### PR DESCRIPTION
Fix for https://github.com/rstudio/tfdeploy/issues/22, Python 3 requires cast from `KeyViews` to `list`.