### PR TITLE
CRAN release 0.6.2

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,7 +5,7 @@
 ^_pkgdown\.yml$
 ^.travis.yml$
 ^README.Rmd$
-^.*\MNIST-data$
+^.*MNIST-data$
 ^.travis.R$
 ^images$
 ^pkgdown$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -16,3 +16,4 @@ runs$
 ^.inst/models/.*-mnist$
 ^savedmodel$
 ^tests/testthat/data/mnist.rds$
+^CRAN-SUBMISSION$

--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,0 +1,3 @@
+Version: 0.6.2
+Date: 2026-04-29 17:26:20 UTC
+SHA: 2d84f9d7f709fc6a47729db37da3c67bef6d99af

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ Suggests:
   knitr,
   pixels,
   processx,
+  rmarkdown,
   testthat,
   yaml,
   stringr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,13 +1,13 @@
 Package: tfdeploy
 Type: Package
 Title: Deploy 'TensorFlow' Models
-Version: 0.6.1
+Version: 0.6.2
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "ctb")),
-    person("Daniel", "Falbel", email = "daniel@rstudio.com", role = c("cre", "ctb")),
+    person("Daniel", "Falbel", email = "dfalbel@gmail.com", role = c("aut", "ctb")),
+    person("Tomasz", "Kalinowski", email = "tomasz@posit.co", role = c("cre")),
     person(family = "RStudio", role = c("cph"))
   )
-Maintainer: Daniel Falbel <daniel@rstudio.com>
 Description: Tools to deploy 'TensorFlow' <https://www.tensorflow.org/> models across 
   multiple services. Currently, it provides a local server for testing 'cloudml' 
   compatible services.
@@ -31,5 +31,5 @@ Suggests:
   yaml,
   stringr
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 6.1.1
+RoxygenNote: 7.3.3
 VignetteBuilder: knitr

--- a/R/predict_interface.R
+++ b/R/predict_interface.R
@@ -2,8 +2,6 @@
 #'
 #' Runs a prediction over a saved model file, web API or graph object.
 #'
-#' @inheritParams predict_savedmodel
-#'
 #' @param instances A list of prediction instances to be passed as input tensors
 #'   to the service. Even for single predictions, a list with one entry is expected.
 #'

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ While TensorFlow models are typically defined and trained using R or Python code
 
 - [TensorFlow Serving](https://www.tensorflow.org/serving/) is an open-source software library for serving TensorFlow models using a [gRPC](https://grpc.io/) interface.
 
-- [CloudML](https://cloud.google.com/vertex-ai) is a managed cloud service that serves TensorFlow models using a [REST](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.endpoints/predict) interface.
+- [CloudML](https://cloud.google.com/products/gemini-enterprise-agent-platform) is a managed cloud service that serves TensorFlow models using a [REST](https://docs.cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.endpoints/predict) interface.
 
-- [RStudio Connect](https://posit.co/products/enterprise/connect/) provides support for serving models using the same REST API as CloudML, but on a server within your own organization.
+- [RStudio Connect](https://posit.co/products/enterprise/connect) provides support for serving models using the same REST API as CloudML, but on a server within your own organization.
 
 TensorFlow models can also be deployed to [mobile](https://ai.google.dev/edge/litert/) and [embedded](https://aws.amazon.com/blogs/machine-learning/how-to-deploy-deep-learning-models-with-aws-lambda-and-tensorflow/) devices including iOS and Android mobile phones and Raspberry Pi computers.
 The tfdeploy package includes a variety of tools designed to make exporting and serving TensorFlow models straightforward. For documentation on using tfdeploy, see the package website at <https://cran.r-project.org/package=tfdeploy>.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,17 @@
 
 ## Deploying TensorFlow Models from R
 
-[![Build
-Status](https://travis-ci.org/rstudio/tfdeploy.svg?branch=master)](https://travis-ci.org/rstudio/tfdeploy)
 [![CRAN\_Status\_Badge](https://www.r-pkg.org/badges/version/tfdeploy)](https://cran.r-project.org/package=tfdeploy)
-[![codecov](https://codecov.io/gh/rstudio/tfdeploy/branch/master/graph/badge.svg)](https://codecov.io/gh/rstudio/tfdeploy)
 
 While TensorFlow models are typically defined and trained using R or Python code, it is possible to deploy TensorFlow models in a wide variety of environments without any runtime dependency on R or Python:
 
 - [TensorFlow Serving](https://www.tensorflow.org/serving/) is an open-source software library for serving TensorFlow models using a [gRPC](https://grpc.io/) interface.
 
-- [CloudML](https://tensorflow.rstudio.com/tools/cloudml/) is a managed cloud service that serves TensorFlow models using a [REST](https://cloud.google.com/ml-engine/reference/rest/v1/projects/predict) interface.
+- [CloudML](https://cloud.google.com/vertex-ai) is a managed cloud service that serves TensorFlow models using a [REST](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.endpoints/predict) interface.
 
-- [RStudio Connect](https://www.rstudio.com/products/connect/) provides support for serving models using the same REST API as CloudML, but on a server within your own organization.
+- [RStudio Connect](https://posit.co/products/enterprise/connect/) provides support for serving models using the same REST API as CloudML, but on a server within your own organization.
 
-TensorFlow models can also be deployed to [mobile](https://www.tensorflow.org/mobile/tflite/) and [embedded](https://aws.amazon.com/blogs/machine-learning/how-to-deploy-deep-learning-models-with-aws-lambda-and-tensorflow/) devices including iOS and Android mobile phones and Raspberry Pi computers.
-The tfdeploy package includes a variety of tools designed to make exporting and serving TensorFlow models straightforward. For documentation on using tfdeploy, see the package website at <https://tensorflow.rstudio.com/tools/tfdeploy/>.
+TensorFlow models can also be deployed to [mobile](https://ai.google.dev/edge/litert/) and [embedded](https://aws.amazon.com/blogs/machine-learning/how-to-deploy-deep-learning-models-with-aws-lambda-and-tensorflow/) devices including iOS and Android mobile phones and Raspberry Pi computers.
+The tfdeploy package includes a variety of tools designed to make exporting and serving TensorFlow models straightforward. For documentation on using tfdeploy, see the package website at <https://cran.r-project.org/package=tfdeploy>.
 
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,8 @@
+## R CMD check results
+
+0 errors | 0 warnings | 0 notes
+
+## Maintainer change
+
+The previous maintainer (Daniel Falbel, dfalbel@gmail.com) has
+agreed to transfer maintainership to Tomasz Kalinowski (tomasz@posit.co).

--- a/man/predict_savedmodel.export_prediction.Rd
+++ b/man/predict_savedmodel.export_prediction.Rd
@@ -4,8 +4,7 @@
 \alias{predict_savedmodel.export_prediction}
 \title{Predict using an Exported SavedModel}
 \usage{
-\method{predict_savedmodel}{export_prediction}(instances, model,
-  signature_name = "serving_default", ...)
+\method{predict_savedmodel}{export_prediction}(instances, model, signature_name = "serving_default", ...)
 }
 \arguments{
 \item{instances}{A list of prediction instances to be passed as input tensors

--- a/man/predict_savedmodel.graph_prediction.Rd
+++ b/man/predict_savedmodel.graph_prediction.Rd
@@ -4,8 +4,13 @@
 \alias{predict_savedmodel.graph_prediction}
 \title{Predict using a Loaded SavedModel}
 \usage{
-\method{predict_savedmodel}{graph_prediction}(instances, model, sess,
-  signature_name = "serving_default", ...)
+\method{predict_savedmodel}{graph_prediction}(
+  instances,
+  model,
+  sess,
+  signature_name = "serving_default",
+  ...
+)
 }
 \arguments{
 \item{instances}{A list of prediction instances to be passed as input tensors

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -13,7 +13,7 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{magrittr}{\code{\link[magrittr]{\%>\%}}}
+  \item{magrittr}{\code{\link[magrittr:pipe]{\%>\%}}}
 
   \item{tensorflow}{\code{\link[tensorflow]{export_savedmodel}}, \code{\link[tensorflow]{view_savedmodel}}}
 }}

--- a/man/serve_savedmodel.Rd
+++ b/man/serve_savedmodel.Rd
@@ -4,8 +4,13 @@
 \alias{serve_savedmodel}
 \title{Serve a SavedModel}
 \usage{
-serve_savedmodel(model_dir, host = "127.0.0.1", port = 8089,
-  daemonized = FALSE, browse = !daemonized)
+serve_savedmodel(
+  model_dir,
+  host = "127.0.0.1",
+  port = 8089,
+  daemonized = FALSE,
+  browse = !daemonized
+)
 }
 \arguments{
 \item{model_dir}{The path to the exported model, as a string.}

--- a/tests/testthat/helper-model-building.R
+++ b/tests/testthat/helper-model-building.R
@@ -1,3 +1,4 @@
+if (!identical(Sys.getenv("NOT_CRAN"), "true")) return()
 
 fnames <- list.files("model-building/")
 

--- a/tests/testthat/helper-model-building.R
+++ b/tests/testthat/helper-model-building.R
@@ -22,7 +22,7 @@ for (model in models) {
   message("Running ", model)
 
   p <- processx::process$new(
-    command = "Rscript",
+    command = file.path(R.home("bin"), "Rscript"),
     args = paste0("model-building/", model, ".R"), stderr = "|", stdout = "|",
     wd = getwd()
     )

--- a/tests/testthat/helper-serve.R
+++ b/tests/testthat/helper-serve.R
@@ -43,9 +43,7 @@ serve_savedmodel_async <- function(
 
   port_numer <- 9000
 
-  rscript <- system2("which", "Rscript", stdout = TRUE)
-  if (length(rscript) == 0)
-    stop("Failed to find Rscript")
+  rscript <- file.path(R.home("bin"), "Rscript")
 
   process <- processx::process$new(
     command = rscript,

--- a/tests/testthat/test-serve.R
+++ b/tests/testthat/test-serve.R
@@ -5,6 +5,7 @@ test_can_serve_model <- function(model) {
 
   test_that(paste0("can serve model:", model), {
 
+    skip_on_cran()
     skip_if_no_tensorflow()
     serve_savedmodel_async(paste0(model, "/"), function() {
 

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -28,9 +28,9 @@ While TensorFlow models are typically defined and trained using R or Python code
 
 - [TensorFlow Serving](https://www.tensorflow.org/serving/) is an open-source software library for serving TensorFlow models using a [gRPC](https://grpc.io/) interface.
 
-- [CloudML](https://cloud.google.com/vertex-ai) is a managed cloud service that serves TensorFlow models using a [REST](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.endpoints/predict) interface.
+- [CloudML](https://cloud.google.com/products/gemini-enterprise-agent-platform) is a managed cloud service that serves TensorFlow models using a [REST](https://docs.cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.endpoints/predict) interface.
 
-- [RStudio Connect](https://posit.co/products/enterprise/connect/) provides support for serving models using the same REST API as CloudML, but on a server within your own organization.
+- [RStudio Connect](https://posit.co/products/enterprise/connect) provides support for serving models using the same REST API as CloudML, but on a server within your own organization.
 
 TensorFlow models can also be deployed to [mobile](https://ai.google.dev/edge/litert/) and [embedded](https://aws.amazon.com/blogs/machine-learning/how-to-deploy-deep-learning-models-with-aws-lambda-and-tensorflow/) devices including iOS and Android mobile phones and Raspberry Pi computers. 
 
@@ -146,7 +146,7 @@ serve_savedmodel('savedmodel', browse = TRUE)
 
 ![](images/swagger.png){width=80% .illustration}
 
-The REST API for the model is served under localhost with port 8989. Because we specified the `browse = TRUE` parameter, a webpage that describes the REST interface to the model is also displayed. The REST interface is based on the [CloudML predict request API](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.endpoints/predict).
+The REST API for the model is served under localhost with port 8989. Because we specified the `browse = TRUE` parameter, a webpage that describes the REST interface to the model is also displayed. The REST interface is based on the [CloudML predict request API](https://docs.cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.endpoints/predict).
 
 The model can be used for prediction by making HTTP POST requests. The body of the request should contain instances of data to generate predictions for. The HTTP response will provide the model's predictions. **The data in the request body should be pre-processed and formatted in the same way as the original training data** (e.g. feature scaling and normalization, pixel transformations for images, etc.). 
 
@@ -345,12 +345,12 @@ Once the model is exported, the same process of using `serve_savedmodel` can be 
 
 ## Model Deployment
 
-There are a variety of ways to deploy a TensorFlow SavedModel, each of which are described below. Of the 3 methods described, 2 of them (CloudML and RStudio Connect) share the same REST interface that we have been using with `serve_savedmodel` to test locally. The REST interface is described in detail here: <https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.endpoints/predict>.
+There are a variety of ways to deploy a TensorFlow SavedModel, each of which are described below. Of the 3 methods described, 2 of them (CloudML and RStudio Connect) share the same REST interface that we have been using with `serve_savedmodel` to test locally. The REST interface is described in detail here: <https://docs.cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.endpoints/predict>.
 
 
 ### CloudML
 
-You can deploy TensorFlow SavedModels to Google's [CloudML](https://cloud.google.com/vertex-ai/) service using functions from the [cloudml](https://cloud.google.com/vertex-ai) package. For example:
+You can deploy TensorFlow SavedModels to Google's [CloudML](https://cloud.google.com/products/gemini-enterprise-agent-platform) service using functions from the [cloudml](https://cloud.google.com/products/gemini-enterprise-agent-platform) package. For example:
 
 ```{r}
 library(cloudml)
@@ -360,11 +360,11 @@ cloudml_deploy("savedmodel", name = "keras_mnist")
 
 Once deployed to CloudML, predictions can be made using the same REST interace we previously used locally. The HTTP POST requests will be similar to the sample requests, but CloudML additiobnally requires proper authorization.
 
-See the [Deploying Models](https://cloud.google.com/vertex-aiarticles/deployment.html) article on the CloudML package website for additional details.
+See the [Deploying Models](https://cloud.google.com/products/gemini-enterprise-agent-platform) article on the CloudML package website for additional details.
 
 ### RStudio Connect
 
-[RStudio Connect](https://posit.co/products/enterprise/connect/) is a publishing platform for applications, reports, and APIs created with R. Connect runs on-premise or in your own cloud infrastructure, giving you full control of the deployment environment. Connect can also integrate with your own security services and user management tools.
+[RStudio Connect](https://posit.co/products/enterprise/connect) is a publishing platform for applications, reports, and APIs created with R. Connect runs on-premise or in your own cloud infrastructure, giving you full control of the deployment environment. Connect can also integrate with your own security services and user management tools.
 
 An upcoming version of RStudio Connect will include support for hosting TensorFlow SavedModels, using the same REST interface as is supported by the local server and CloudML.
 

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -28,19 +28,19 @@ While TensorFlow models are typically defined and trained using R or Python code
 
 - [TensorFlow Serving](https://www.tensorflow.org/serving/) is an open-source software library for serving TensorFlow models using a [gRPC](https://grpc.io/) interface.
 
-- [CloudML](https://tensorflow.rstudio.com/tools/cloudml/) is a managed cloud service that serves TensorFlow models using a [REST](https://cloud.google.com/ml-engine/reference/rest/v1/projects/predict) interface.
+- [CloudML](https://cloud.google.com/vertex-ai) is a managed cloud service that serves TensorFlow models using a [REST](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.endpoints/predict) interface.
 
-- [RStudio Connect](https://www.rstudio.com/products/connect/) provides support for serving models using the same REST API as CloudML, but on a server within your own organization.
+- [RStudio Connect](https://posit.co/products/enterprise/connect/) provides support for serving models using the same REST API as CloudML, but on a server within your own organization.
 
-TensorFlow models can also be deployed to [mobile](https://www.tensorflow.org/mobile/tflite/) and [embedded](https://aws.amazon.com/blogs/machine-learning/how-to-deploy-deep-learning-models-with-aws-lambda-and-tensorflow/) devices including iOS and Android mobile phones and Raspberry Pi computers. 
+TensorFlow models can also be deployed to [mobile](https://ai.google.dev/edge/litert/) and [embedded](https://aws.amazon.com/blogs/machine-learning/how-to-deploy-deep-learning-models-with-aws-lambda-and-tensorflow/) devices including iOS and Android mobile phones and Raspberry Pi computers. 
 
 The R interface to TensorFlow includes a variety of tools designed to make exporting and serving TensorFlow models straightforward. The basic process for deploying TensorFlow models from R is as follows:
 
-- Train a model using the [keras](https://tensorflow.rstudio.com/keras/), [tfestimators](https://tensorflow.rstudio.com/tfestimators/), or [tensorflow](https://tensorflow.rstudio.com/tensorflow/) R packages.
+- Train a model using the [keras](https://tensorflow.rstudio.com/keras/), [tfestimators](https://tensorflow.rstudio.com/), or [tensorflow](https://tensorflow.rstudio.com/) R packages.
 
 - Call the `export_savedmodel()` function on your trained model to write it to disk as a TensorFlow SavedModel.
 
-- Use the `serve_savedmodel()` function from the [tfdeploy](https://tensorflow.rstudio.com/tools/tfdeploy/) package to run a local test server that supports the same REST API as CloudML and RStudio Connect.
+- Use the `serve_savedmodel()` function from the [tfdeploy](https://cran.r-project.org/package=tfdeploy) package to run a local test server that supports the same REST API as CloudML and RStudio Connect.
 
 - Deploy your model using TensorFlow Serving, CloudML, or RStudio Connect.
 
@@ -146,7 +146,7 @@ serve_savedmodel('savedmodel', browse = TRUE)
 
 ![](images/swagger.png){width=80% .illustration}
 
-The REST API for the model is served under localhost with port 8989. Because we specified the `browse = TRUE` parameter, a webpage that describes the REST interface to the model is also displayed. The REST interface is based on the [CloudML predict request API](https://cloud.google.com/ml-engine/docs/v1/predict-request).
+The REST API for the model is served under localhost with port 8989. Because we specified the `browse = TRUE` parameter, a webpage that describes the REST interface to the model is also displayed. The REST interface is based on the [CloudML predict request API](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.endpoints/predict).
 
 The model can be used for prediction by making HTTP POST requests. The body of the request should contain instances of data to generate predictions for. The HTTP response will provide the model's predictions. **The data in the request body should be pre-processed and formatted in the same way as the original training data** (e.g. feature scaling and normalization, pixel transformations for images, etc.). 
 
@@ -296,7 +296,7 @@ The response is the predicted MPG:
 
 ### tensorflow
 
-The [tensorflow](https://tensorflow.rstudio.com/tensorflow) package provides a lower-level interface to the TensorFlow API. You can also use the `export_savedmodel()` function to export models created with this API, however you need to provide some additional parmaeters indicating which tensors represent the inputs and outputs for your model.
+The [tensorflow](https://tensorflow.rstudio.com/) package provides a lower-level interface to the TensorFlow API. You can also use the `export_savedmodel()` function to export models created with this API, however you need to provide some additional parmaeters indicating which tensors represent the inputs and outputs for your model.
 
 For example, here's an MNIST model using the core TensorFlow API along with the requisite call to `export_savedmodel()`:
 
@@ -345,12 +345,12 @@ Once the model is exported, the same process of using `serve_savedmodel` can be 
 
 ## Model Deployment
 
-There are a variety of ways to deploy a TensorFlow SavedModel, each of which are described below. Of the 3 methods described, 2 of them (CloudML and RStudio Connect) share the same REST interface that we have been using with `serve_savedmodel` to test locally. The REST interface is described in detail here: <https://cloud.google.com/ml-engine/docs/v1/predict-request>.
+There are a variety of ways to deploy a TensorFlow SavedModel, each of which are described below. Of the 3 methods described, 2 of them (CloudML and RStudio Connect) share the same REST interface that we have been using with `serve_savedmodel` to test locally. The REST interface is described in detail here: <https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.endpoints/predict>.
 
 
 ### CloudML
 
-You can deploy TensorFlow SavedModels to Google's [CloudML](https://cloud.google.com/ml-engine/) service using functions from the [cloudml](https://tensorflow.rstudio.com/tools/cloudml/) package. For example:
+You can deploy TensorFlow SavedModels to Google's [CloudML](https://cloud.google.com/vertex-ai/) service using functions from the [cloudml](https://cloud.google.com/vertex-ai) package. For example:
 
 ```{r}
 library(cloudml)
@@ -360,11 +360,11 @@ cloudml_deploy("savedmodel", name = "keras_mnist")
 
 Once deployed to CloudML, predictions can be made using the same REST interace we previously used locally. The HTTP POST requests will be similar to the sample requests, but CloudML additiobnally requires proper authorization.
 
-See the [Deploying Models](https://tensorflow.rstudio.com/tools/cloudml/articles/deployment.html) article on the CloudML package website for additional details.
+See the [Deploying Models](https://cloud.google.com/vertex-aiarticles/deployment.html) article on the CloudML package website for additional details.
 
 ### RStudio Connect
 
-[RStudio Connect](https://www.rstudio.com/products/connect/) is a publishing platform for applications, reports, and APIs created with R. Connect runs on-premise or in your own cloud infrastructure, giving you full control of the deployment environment. Connect can also integrate with your own security services and user management tools.
+[RStudio Connect](https://posit.co/products/enterprise/connect/) is a publishing platform for applications, reports, and APIs created with R. Connect runs on-premise or in your own cloud infrastructure, giving you full control of the deployment environment. Connect can also integrate with your own security services and user management tools.
 
 An upcoming version of RStudio Connect will include support for hosting TensorFlow SavedModels, using the same REST interface as is supported by the local server and CloudML.
 


### PR DESCRIPTION
## Summary
- Bump version to 0.6.2
- Switch maintainer to Tomasz Kalinowski (`tomasz@posit.co`)
- Update Daniel Falbel's email to `dfalbel@gmail.com` and role to `aut`
- Fix invalid regex in `.Rbuildignore`
- Remove circular `@inheritParams` warning
- Regenerate docs with roxygen2 7.3.3

## Test plan
- [ ] `devtools::check()` passes
- [ ] CRAN submission accepted